### PR TITLE
opencode: drop redundant version line (inferred from URL)

### DIFF
--- a/opencode.rb
+++ b/opencode.rb
@@ -5,7 +5,6 @@
 class Opencode < Formula
   desc "The AI coding agent built for the terminal."
   homepage "https://github.com/anomalyco/opencode"
-  version "1.18.23"
 
   depends_on "ripgrep"
 


### PR DESCRIPTION
Fixes the brew audit error:

> * Stable: `version 1.18.23` is redundant with version scanned from URL

The version is already determinable from the download URL, so the explicit `version "1.18.23"` line is removed.