### PR TITLE
feat(cask): add Hex

### DIFF
--- a/Casks/hex.rb
+++ b/Casks/hex.rb
@@ -1,0 +1,21 @@
+cask "hex" do
+  version "2.1.15"
+  sha256 "783db9a5ee2bcc44f58e3fc1b7d2d3de30a6e93f862764639fd7dff08e55537f"
+
+  url "https://pub-089d681d41754031a4aefa7017d8c2fb.r2.dev/releases/HEX-#{version}-arm64.dmg",
+      verified: "pub-089d681d41754031a4aefa7017d8c2fb.r2.dev/"
+  name "Hex"
+  desc "Local-first voice dictation"
+  homepage "https://hex.kitlangton.dev/"
+
+  livecheck do
+    url "https://pub-089d681d41754031a4aefa7017d8c2fb.r2.dev/appcast.xml"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  depends_on arch: :arm64
+  depends_on macos: :sequoia
+
+  app "Hex.app"
+end


### PR DESCRIPTION
## Why

HEX currently requires a manual DMG download. Adding the signed macOS app to the existing tap gives users a Homebrew installation path, as requested in https://github.com/anomalyco/hex/issues/69.

## What Changes

Install with `brew install --cask anomalyco/tap/hex`.

- Pin the published Hex 2.1.15 DMG and its SHA-256 checksum.
- Require Apple silicon and macOS 15 or newer.
- Install `Hex.app` and retain its built-in Sparkle updater with `auto_updates true`.
- Discover subsequent app versions from the Rust Sparkle feed, not the repository's separate TypeScript SDK releases.

## Scope

This adds one app cask, with no source build, mandatory OpenCode/Bun dependency, launch hook, or data migration. Existing app destinations are not forcibly replaced, and uninstall does not delete settings, models, or history.

## Verification

```sh
brew style Casks/hex.rb
brew audit --cask --strict --online anomalyco/tap/hex
brew livecheck --cask anomalyco/tap/hex
brew fetch --cask anomalyco/tap/hex
brew install --cask --appdir "$apps" anomalyco/tap/hex
brew list --cask --versions hex
brew uninstall --cask hex
```

Style and strict online audit passed. Livecheck resolves 2.1.15, and the public download matches the pinned checksum. Installation and removal passed with `$apps` pointing to a fresh temporary directory. The installed candidate passed HEX's bundle-identity/signature checks, stapled-ticket validation, and Gatekeeper assessment.

A separate existing-app fixture was rejected without changing its contents. The real installed app's Info.plist and executable hashes were unchanged. No app launch, microphone capture, or Sparkle installation was performed.
