### PR TITLE
chore(hex): update cask to 2.1.16

### DIFF
--- a/Casks/hex.rb
+++ b/Casks/hex.rb
@@ -1,6 +1,6 @@
 cask "hex" do
-  version "2.1.15"
-  sha256 "783db9a5ee2bcc44f58e3fc1b7d2d3de30a6e93f862764639fd7dff08e55537f"
+  version "2.1.16"
+  sha256 "102dc1a8d80dc359ee15a30141957b6a311e581214b44a3c615026fa91288b8a"
 
   url "https://pub-089d681d41754031a4aefa7017d8c2fb.r2.dev/releases/HEX-#{version}-arm64.dmg",
       verified: "pub-089d681d41754031a4aefa7017d8c2fb.r2.dev/"


### PR DESCRIPTION
## Why

The cask still installs Hex 2.1.15. The signed 2.1.16 release fixes missing passages
in long Cohere recordings and adds quick switching between downloaded models from
the menu bar.

## What Changes

- **Before:** version 2.1.15 and its pinned DMG checksum.
- **After:** version 2.1.16 and the checksum verified against the published DMG.

[Release notes](https://github.com/anomalyco/hex/blob/main/docs/releases/2.1.16.md)
and [signed DMG](https://pub-089d681d41754031a4aefa7017d8c2fb.r2.dev/releases/HEX-2.1.16-arm64.dmg).

## Scope

Only the version and checksum change. Apple silicon/macOS requirements, Sparkle
updates, installation behavior, and preservation of user data remain unchanged.

## Verification

```sh
brew style Casks/hex.rb
brew audit --cask --strict --online anomalyco/tap/hex
brew livecheck --cask anomalyco/tap/hex
brew fetch --cask --force anomalyco/tap/hex
brew install --cask --appdir="$isolated_appdir" anomalyco/tap/hex
brew uninstall --cask hex
```

All passed. The isolated installed app passed identity/version/build, signature,
stapled-ticket, and Gatekeeper checks. Uninstall removed the isolated app and cask
registration. An existing-app fixture was refused without replacement. No app was
launched. Fresh public downloads matched the prepared artifacts, and the Sparkle
ZIP signature verified against the signed app's public key.
